### PR TITLE
Applied ryanjmulder's suggestions for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,14 @@ At the moment, these drivers are very much in **beta** and additional feature an
 
 ## Post Invite Activities
 
-After accepting this channel invite and enrolling, any HomeSeer switches you add should automatically be assigned this Device Type Handler (DTH).
+After accepting this channel invite and enrolling, any HomeSeer switches you add should automatically be assigned this Edge Driver.
 
-To see if a switch is using this device handler, go to Devices, open the switch and click the "..." button. If "Driver" is in the list, then it's using the new Edge Driver code. The driver name will be "HomeSeer Z-Wave Switches". If "Driver" is not present, it's using the legacy Groovy handler. In this case you should remove the device and re-add it.
+To see if a switch is using this device driver, go to Devices, open the switch and click the "..." button. If "Driver" is in the list, then it's using the new Edge Driver code. The driver name will be "HomeSeer Z-Wave Switches". If "Driver" is not present, it's using the legacy Groovy Device Type Handler (DTH). In this case you should remove the device and re-add it.
 
-# Removing the old handler
+### Removing the old handler
 
-When removing the device via the SmartThings app, it will prompt you to follow your manufacturer's directions to unpair the old device. For all models the factory reset sequence is:
+When removing the device via the SmartThings app, it will prompt you to follow your manufacturer's directions to exclude the old device. Once the exclusion process is started by the app, single click and release the rocker switch.
 
-1) Turn the light on.
-2) Quickly tap up 3 times
-3) Quickly tap down 3 times
-
-If it worked, it will turn the light off then back on again, and the remove operation will complete successfully in the SmartThings app.
-
-Newer models like WX300 have a dedicated Z-Wave exclusion mode which you should use instead as it doesn't reset the switch wiring mode.
-
-# Assigning multi-tap actions
+## Assigning multi-tap actions
 
 To react to a multi-tap event, go to Automation and create a Routine. Under "If", choose "Device status", choose the switch and it should show all of the multi-tap events you can react to. Then you can add the result as normal for the routine.


### PR DESCRIPTION
It looks like what's in the Readme now came from my first draft PR ryanjmulder's repo. He made some good suggestions before it was merged there; I'm applying those changes here as well since this is the new root repo.

The changes being:
* We shouldn't need to factory reset when removing a switch, just tapping it will do
* Refer to this new code consistently as an Edge Driver rather than a device handler

Signed-off-by: David Rickard <david.rickard@gmail.com>